### PR TITLE
Add JIRA Issue Collector

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/*          @Cray-HPE/metal
+*          @Cray-HPE/metal

--- a/src/partials/header-scripts.hbs
+++ b/src/partials/header-scripts.hbs
@@ -1,1 +1,19 @@
-{{!-- Add header scripts here --}}
+<script src="http://code.jquery.com/jquery-latest.js"></script>
+<script src="https://jira-pro.it.hpe.com:8443/plugins/servlet/issueCollectorBootstrap.js?collectorId=e49dd2fa&locale=en_US"></script>
+<script type="text/javascript">
+window.ATL_JQ_PAGE_PROPS = $.extend(window.ATL_JQ_PAGE_PROPS, {
+
+  // ==== custom trigger function ====
+  triggerFunction: function (showCollectorDialog) {
+    $('#feedback-button').on('click', function (e) {
+      e.preventDefault()
+      showCollectorDialog()
+    })
+  },
+  fieldValues: {
+    // By default, record web info in order to grab the page, doc-version, and the section (if in the URL).
+    recordWebInfo: '1', // field Name
+    recordWebInfoConsent: ['1'] // field id
+  }
+})
+</script>


### PR DESCRIPTION
This adds a JIRA Issue Collector, a new form that files JIRAs.

The new form includes the browser information, such as the current web page and browser information.

The user may also include their name, email, and a description of the problem before filing.

If the user inputs their work email, and that email has a JIRA account with issue reporter access then the created issue will list them as the reporter. Otherwise, it'll set a default reporter of Dennis Walker.

https://github.com/Cray-HPE/antora-ui/assets/7772179/d37d3c38-f9d1-4ced-9384-f0c2379a0c75

