### PR TITLE
Fix request blocks for fetching the jquery lib

### DIFF
--- a/src/partials/header-scripts.hbs
+++ b/src/partials/header-scripts.hbs
@@ -1,4 +1,4 @@
-<script src="http://code.jquery.com/jquery-latest.js"></script>
+<script src="https://code.jquery.com/jquery-latest.js"></script>
 <script src="https://jira-pro.it.hpe.com:8443/plugins/servlet/issueCollectorBootstrap.js?collectorId=e49dd2fa&locale=en_US"></script>
 <script type="text/javascript">
 window.ATL_JQ_PAGE_PROPS = $.extend(window.ATL_JQ_PAGE_PROPS, {


### PR DESCRIPTION
The following error is observed in newer browsers when using the http URL: `This request has been blocked; the content must be served over HTTPS.`

Replace the URL with https to satisfy the block.
![image](https://github.com/Cray-HPE/antora-ui/assets/7772179/7647d7ee-7ae9-4a27-9de4-1275a0dd93fc)
